### PR TITLE
Fix return filtered list for Unattend

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UnattendCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnattendCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
- Unattend will return the same list as the list it was executed in.
- E.g. if we sort by name and did the unattend command for the first index, the list that is returned will be the same sorted list with updated attendance for that index.